### PR TITLE
Run hadolint on all Dockerfiles

### DIFF
--- a/.devcontainer/Dockerfile.devcontainer
+++ b/.devcontainer/Dockerfile.devcontainer
@@ -3,10 +3,14 @@ FROM cruizba/ubuntu-dind:noble-28.2.1
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 \
-    python3-venv \
-    python3-pip \
+    python3=3.12.3-0ubuntu2 \
+    python3-venv=3.12.3-0ubuntu2 \
+    python3-pip=24.0+dfsg-1ubuntu1.2 \
     && rm -rf /var/lib/apt/lists/*
+
+# install hadolint for Dockerfile linting
+RUN curl -Ls https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64 -o /usr/local/bin/hadolint \
+    && chmod +x /usr/local/bin/hadolint
 
 COPY postStart.sh /usr/local/bin/postStart.sh
 RUN chmod +x /usr/local/bin/postStart.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ ENV COMMIT_SHA=${COMMIT_SHA}
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ffmpeg \
-    genisoimage \
-    dvd+rw-tools \
-    udftools \
-    xorriso \
+    ffmpeg=7:6.1.1-3ubuntu5 \
+    genisoimage=9:1.1.11-3.5 \
+    dvd+rw-tools=7.1-14build2 \
+    udftools=2.3-1build2 \
+    xorriso=1:1.5.6-1.1ubuntu3 \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/agents-check.sh
+++ b/agents-check.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 pip install --quiet \
     black==25.1.0 \
     ruff==0.3.7 \
     mypy==1.10.0 \
     pytest==8.2.2
+# install hadolint
+curl -Ls https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64 -o /usr/local/bin/hadolint
+chmod +x /usr/local/bin/hadolint
 ./check.sh

--- a/check.sh
+++ b/check.sh
@@ -13,5 +13,6 @@ fi
 
 black --check .
 ruff check .
+git ls-files -z -- '*Dockerfile*' | xargs -0 hadolint
 mypy --no-site-packages --explicit-package-bases scripts utils.py
 pytest -q


### PR DESCRIPTION
## Summary
- remove conditional execution of `hadolint` in `check.sh`
- always lint Dockerfiles so missing or failing linting stops the check

## Testing
- `./check.sh`
- `bash agents-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_687bf459d6f8832ba1766dfef0ad142a