### PR TITLE
Refactor acceptance tests with shared helpers

### DIFF
--- a/scripts/analyse_loudness/test/test_acceptance.py
+++ b/scripts/analyse_loudness/test/test_acceptance.py
@@ -3,15 +3,14 @@ from __future__ import annotations
 import json
 import math
 import os
-import subprocess
-import sys
 import wave
 from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
-from shared import compose
+from shared.acceptance import run_script
+
+from shared import compose  # noqa: E402
 
 
 def make_wav(path: Path) -> None:
@@ -101,7 +100,6 @@ def test_s2_missing_input() -> None:
 
 
 def test_s3_unwritable_out_json(tmp_path: Path) -> None:
-    script = Path(__file__).resolve().parents[1] / "analyse_loudness.py"
     fake_ffmpeg = tmp_path / "ffmpeg"
     metrics = Path("/proc/metrics.json")
     fake_ffmpeg.write_text(
@@ -109,23 +107,17 @@ def test_s3_unwritable_out_json(tmp_path: Path) -> None:
     )
     fake_ffmpeg.chmod(0o755)
     log = tmp_path / "log.txt"
-    env = os.environ.copy()
-    env["PATH"] = f"{tmp_path}:{env['PATH']}"
-    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[3])
-    proc = subprocess.run(
-        [
-            sys.executable,
-            str(script),
-            "--logfile",
-            str(log),
-            "--in-file",
-            "dummy.wav",
-            "--out-json",
-            str(metrics),
-        ],
-        capture_output=True,
-        text=True,
-        env=env,
+    env = {"PATH": f"{tmp_path}:{os.environ['PATH']}"}
+    proc = run_script(
+        "analyse_loudness",
+        tmp_path,
+        "--logfile",
+        str(log),
+        "--in-file",
+        "dummy.wav",
+        "--out-json",
+        str(metrics),
+        env_extra=env,
         check=False,
     )
     assert proc.returncode != 0

--- a/scripts/burn_iso/test/test_acceptance.py
+++ b/scripts/burn_iso/test/test_acceptance.py
@@ -1,17 +1,14 @@
 from __future__ import annotations
 
 import os
-import subprocess
-import sys
 from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
-
-from shared import compose
 
 import pytest
 
-from scripts.burn_iso.burn_iso import _build_command
+from shared.acceptance import run_script
+
+from shared import compose  # noqa: E402
+from scripts.burn_iso.burn_iso import _build_command  # noqa: E402
 
 
 @pytest.mark.skipif(
@@ -46,7 +43,6 @@ def test_container_dry_run() -> None:
 
 
 def test_s10_dry_run(tmp_path: Path) -> None:
-    script = Path(__file__).resolve().parents[1] / "burn_iso.py"
     iso = tmp_path / "dummy.iso"
     iso.write_bytes(b"iso")
     log = tmp_path / "burn.log"
@@ -55,27 +51,20 @@ def test_s10_dry_run(tmp_path: Path) -> None:
     dummy = fake_bin / "growisofs"
     dummy.write_text("#!/bin/sh\nexit 0")
     dummy.chmod(0o755)
-    env = os.environ.copy()
-    env["PATH"] = f"{fake_bin}:{env['PATH']}"
-    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[3])
-    proc = subprocess.run(
-        [
-            sys.executable,
-            str(script),
-            "--iso-path",
-            str(iso),
-            "--dry-run",
-            "--speed",
-            "4",
-            "--device",
-            "/dev/sr0",
-            "--logfile",
-            str(log),
-            "--skip-verify",
-        ],
-        capture_output=True,
-        text=True,
-        env=env,
+    proc = run_script(
+        "burn_iso",
+        tmp_path,
+        "--iso-path",
+        str(iso),
+        "--dry-run",
+        "--speed",
+        "4",
+        "--device",
+        "/dev/sr0",
+        "--logfile",
+        str(log),
+        "--skip-verify",
+        env_extra={"PATH": f"{fake_bin}:{os.environ['PATH']}"},
     )
     assert proc.returncode == 0
     expected = f"growisofs -dvd-compat -speed=4 -Z /dev/sr0={iso}"
@@ -86,23 +75,15 @@ def test_s10_dry_run(tmp_path: Path) -> None:
 
 
 def test_s4_missing_iso(tmp_path: Path) -> None:
-    script = Path(__file__).resolve().parents[1] / "burn_iso.py"
     missing = tmp_path / "nope.iso"
     log = tmp_path / "burn.log"
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[3])
-    proc = subprocess.run(
-        [
-            sys.executable,
-            str(script),
-            "--iso-path",
-            str(missing),
-            "--logfile",
-            str(log),
-        ],
-        capture_output=True,
-        text=True,
-        env=env,
+    proc = run_script(
+        "burn_iso",
+        tmp_path,
+        "--iso-path",
+        str(missing),
+        "--logfile",
+        str(log),
     )
     assert proc.returncode != 0
     assert "File not found" in proc.stderr
@@ -112,28 +93,20 @@ def test_s4_missing_iso(tmp_path: Path) -> None:
 
 
 def test_s8_logfile_permission_denied(tmp_path: Path) -> None:
-    script = Path(__file__).resolve().parents[1] / "burn_iso.py"
     iso = tmp_path / "dummy.iso"
     iso.write_bytes(b"iso")
     restricted = tmp_path / "no_write"
     restricted.mkdir()
     os.chmod(restricted, 0o500)
     log = restricted / "burn.log"
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[3])
-    proc = subprocess.run(
-        [
-            sys.executable,
-            str(script),
-            "--iso-path",
-            str(iso),
-            "--logfile",
-            str(log),
-            "--dry-run",
-        ],
-        capture_output=True,
-        text=True,
-        env=env,
+    proc = run_script(
+        "burn_iso",
+        tmp_path,
+        "--iso-path",
+        str(iso),
+        "--logfile",
+        str(log),
+        "--dry-run",
     )
     assert proc.returncode != 0
     assert "Permission" in proc.stderr or "FileNotFoundError" in proc.stderr

--- a/scripts/conftest.py
+++ b/scripts/conftest.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure repository root is on sys.path so shared modules can be imported
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from shared.acceptance import add_repo_to_path  # noqa: E402
+
+add_repo_to_path()

--- a/scripts/create_iso/test/test_acceptance.py
+++ b/scripts/create_iso/test/test_acceptance.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 import datetime
 import os
-import subprocess
-import sys
 from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
-from shared import compose
+from shared.acceptance import run_script
+
+from shared import compose  # noqa: E402
 
 
 @pytest.mark.skipif(os.environ.get("IMAGE") is None, reason="IMAGE not available")  # type: ignore[misc]
@@ -84,22 +83,6 @@ def make_dummy_genisoimage(dir: Path) -> None:
     exe.chmod(0o755)
 
 
-def run_script(
-    tmp_path: Path, *args: str, env_extra: dict[str, str] | None = None
-) -> subprocess.CompletedProcess[str]:
-    script = Path(__file__).resolve().parents[1] / "create_iso.py"
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[3])
-    if env_extra:
-        env.update(env_extra)
-    return subprocess.run(
-        [sys.executable, str(script), *args],
-        capture_output=True,
-        text=True,
-        env=env,
-    )
-
-
 def test_s3_label_too_long(tmp_path: Path) -> None:
     build = tmp_path / "build"
     build.mkdir()
@@ -109,6 +92,7 @@ def test_s3_label_too_long(tmp_path: Path) -> None:
     fake_bin.mkdir()
     make_dummy_genisoimage(fake_bin)
     proc = run_script(
+        "create_iso",
         tmp_path,
         "--logfile",
         str(log),
@@ -133,6 +117,7 @@ def test_s4_label_bad_chars(tmp_path: Path) -> None:
     fake_bin.mkdir()
     make_dummy_genisoimage(fake_bin)
     proc = run_script(
+        "create_iso",
         tmp_path,
         "--logfile",
         str(log),
@@ -154,6 +139,7 @@ def test_s5_nonexistent_build_dir(tmp_path: Path) -> None:
     fake_bin.mkdir()
     make_dummy_genisoimage(fake_bin)
     proc = run_script(
+        "create_iso",
         tmp_path,
         "--logfile",
         str(log),
@@ -175,6 +161,7 @@ def test_s6_empty_build_dir(tmp_path: Path) -> None:
     fake_bin.mkdir()
     make_dummy_genisoimage(fake_bin)
     proc = run_script(
+        "create_iso",
         tmp_path,
         "--logfile",
         str(log),
@@ -198,6 +185,7 @@ def test_s7_unwritable_iso_path(tmp_path: Path) -> None:
     fake_bin.mkdir()
     make_dummy_genisoimage(fake_bin)
     proc = run_script(
+        "create_iso",
         tmp_path,
         "--logfile",
         str(log),
@@ -222,6 +210,7 @@ def test_s8_iso_exists_no_force(tmp_path: Path) -> None:
     fake_bin.mkdir()
     make_dummy_genisoimage(fake_bin)
     proc = run_script(
+        "create_iso",
         tmp_path,
         "--logfile",
         str(log),
@@ -246,6 +235,7 @@ def test_s9_iso_exists_with_force(tmp_path: Path) -> None:
     fake_bin.mkdir()
     make_dummy_genisoimage(fake_bin)
     proc = run_script(
+        "create_iso",
         tmp_path,
         "--logfile",
         str(log),
@@ -269,6 +259,7 @@ def test_s10_logfile_unwritable(tmp_path: Path) -> None:
     fake_bin.mkdir()
     make_dummy_genisoimage(fake_bin)
     proc = run_script(
+        "create_iso",
         tmp_path,
         "--logfile",
         str(log),

--- a/scripts/make_shuffle_clips/test/test_acceptance.py
+++ b/scripts/make_shuffle_clips/test/test_acceptance.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
-from shared import compose
+from shared.acceptance import run_script
+
+from shared import compose  # noqa: E402
 
 
 def make_dummy_ffmpeg(dir: Path) -> None:
@@ -49,22 +49,6 @@ print(pathlib.Path(sys.argv[-1]).read_text().strip())
     else:
         exe.write_text(f"#!/bin/sh\necho {dur}\n")
     exe.chmod(0o755)
-
-
-def run_script(
-    tmp_path: Path, *args: str, env_extra: dict[str, str] | None = None
-) -> subprocess.CompletedProcess[str]:
-    script = Path(__file__).resolve().parents[1] / "make_shuffle_clips.py"
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[3])
-    if env_extra:
-        env.update(env_extra)
-    return subprocess.run(
-        [sys.executable, str(script), *args],
-        capture_output=True,
-        text=True,
-        env=env,
-    )
 
 
 @pytest.mark.skipif(os.environ.get("IMAGE") is None, reason="IMAGE not available")  # type: ignore[misc]
@@ -211,6 +195,7 @@ def test_s1_happy_path(tmp_path: Path) -> None:
     out_dir = tmp_path / "tmp"
     out_dir.mkdir()
     proc = run_script(
+        "make_shuffle_clips",
         tmp_path,
         "--logfile",
         str(log),
@@ -256,6 +241,7 @@ def test_s3_even_coverage(tmp_path: Path) -> None:
     out_dir = tmp_path / "tmp"
     out_dir.mkdir()
     proc = run_script(
+        "make_shuffle_clips",
         tmp_path,
         "--logfile",
         str(log),
@@ -324,6 +310,7 @@ def test_s4_keyframe_integrity(tmp_path: Path) -> None:
     out_dir = tmp_path / "tmp"
     out_dir.mkdir()
     proc = run_script(
+        "make_shuffle_clips",
         tmp_path,
         "--logfile",
         str(log),
@@ -376,6 +363,7 @@ def test_s5_invalid_numeric(tmp_path: Path) -> None:
     dummy = tmp_path / "dummy.mp4"
     dummy.write_text("x")
     proc = run_script(
+        "make_shuffle_clips",
         tmp_path,
         "--logfile",
         str(log),
@@ -400,6 +388,7 @@ def test_s6_short_footage(tmp_path: Path) -> None:
     dummy = tmp_path / "dummy.mp4"
     dummy.write_text("x")
     proc = run_script(
+        "make_shuffle_clips",
         tmp_path,
         "--logfile",
         str(log),
@@ -423,6 +412,7 @@ def test_s7_unwritable_tmp(tmp_path: Path) -> None:
     dummy = tmp_path / "dummy.mp4"
     dummy.write_text("x")
     proc = run_script(
+        "make_shuffle_clips",
         tmp_path,
         "--logfile",
         str(log),

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -1,3 +1,17 @@
-from .acceptance import compose, dump_logs, wait_for
+from .acceptance import (
+    compose,
+    dump_logs,
+    wait_for,
+    add_repo_to_path,
+    run_script,
+    script_path,
+)
 
-__all__ = ["compose", "dump_logs", "wait_for"]
+__all__ = [
+    "compose",
+    "dump_logs",
+    "wait_for",
+    "add_repo_to_path",
+    "run_script",
+    "script_path",
+]


### PR DESCRIPTION
## Summary
- consolidate acceptance test helpers into `shared/acceptance.py`
- use a root `scripts/conftest.py` so tests automatically gain access to helpers
- update all acceptance tests to rely on the new conftest

## Testing
- `./agents-check.sh`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_687d6be97044832b9c4909b472643c2f